### PR TITLE
refactor: improve mail server configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+*.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@babel/preset-react": "^7.24.7",
         "@tinymce/tinymce-react": "^5.1.1",
         "antd": "^5.20.5",
-        "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "firebase": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-react": "^7.24.7",
     "@tinymce/tinymce-react": "^5.1.1",
     "antd": "^5.20.5",
-    "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "firebase": "^10.13.1",

--- a/server.js
+++ b/server.js
@@ -3,18 +3,17 @@ require('dotenv').config();
 const express = require('express');
 const nodemailer = require('nodemailer');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 
 const app = express();
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json());
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: Number(process.env.SMTP_PORT),
-  secure: true,
+  secure: Number(process.env.SMTP_PORT) === 465,
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS,
@@ -25,15 +24,19 @@ app.post('/send-mail', async (req, res) => {
   const {
     name,
     phone,
-    email, 
+    email,
     selectedHouse,
     selectedTrademark,
     selectedColor,
-    adminEmail, 
+    adminEmail,
     widgetName,
     pdfUrl,
-    translations 
+    translations
   } = req.body;
+
+  if (!name || !phone || !email || !adminEmail || !widgetName || !pdfUrl || !translations) {
+    return res.status(400).json({ success: false, error: 'Missing required fields' });
+  }
 
   const htmlContent = `
       <h2>${translations.form.letter_header} "${widgetName}"</h2>


### PR DESCRIPTION
## Summary
- replace body-parser with built-in express.json
- make mail server port configurable via env
- add basic validation for incoming mail requests
- ignore build artifacts and environment files

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b5ce8d440c8330bed4f999e5621eb9