### PR TITLE
feat: optimize uploaded images to webp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+*.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@babel/preset-react": "^7.24.7",
         "@tinymce/tinymce-react": "^5.1.1",
         "antd": "^5.20.5",
-        "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "firebase": "^10.13.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-react": "^7.24.7",
     "@tinymce/tinymce-react": "^5.1.1",
     "antd": "^5.20.5",
-    "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "firebase": "^10.13.1",

--- a/server.js
+++ b/server.js
@@ -3,18 +3,17 @@ require('dotenv').config();
 const express = require('express');
 const nodemailer = require('nodemailer');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 
 const app = express();
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json());
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: Number(process.env.SMTP_PORT),
-  secure: true,
+  secure: Number(process.env.SMTP_PORT) === 465,
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS,
@@ -25,15 +24,19 @@ app.post('/send-mail', async (req, res) => {
   const {
     name,
     phone,
-    email, 
+    email,
     selectedHouse,
     selectedTrademark,
     selectedColor,
-    adminEmail, 
+    adminEmail,
     widgetName,
     pdfUrl,
-    translations 
+    translations
   } = req.body;
+
+  if (!name || !phone || !email || !adminEmail || !widgetName || !pdfUrl || !translations) {
+    return res.status(400).json({ success: false, error: 'Missing required fields' });
+  }
 
   const htmlContent = `
       <h2>${translations.form.letter_header} "${widgetName}"</h2>

--- a/src/pages/TM/AddTMForm.tsx
+++ b/src/pages/TM/AddTMForm.tsx
@@ -13,6 +13,7 @@ import {
 } from "antd";
 import { UploadOutlined } from "@ant-design/icons";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import { convertToWebp } from "../../utils/imageUtils";
 import { addTrademark } from "../../services/trademarkService";
 import { getLanguages } from "../../services/languageService";
 import { getColors } from "../../services/colorService";
@@ -97,10 +98,11 @@ const AddTMForm: React.FC<AddTMFormProps> = ({ refreshTable }) => {
 
   const uploadFile = async (file: File, path: string): Promise<string> => {
     try {
+      const optimizedFile = file.type.startsWith("image/") && path !== "pdfs" ? await convertToWebp(file) : file;
       const storage = getStorage();
-      const uniqueFileName = `${uuidv4()}_${file.name}`;
+      const uniqueFileName = `${uuidv4()}_${optimizedFile.name}`;
       const storageRef = ref(storage, `${path}/${uniqueFileName}`);
-      await uploadBytes(storageRef, file);
+      await uploadBytes(storageRef, optimizedFile);
       return getDownloadURL(storageRef);
     } catch (error) {
       console.error(`Помилка завантаження файлу: ${error}`);

--- a/src/services/houseService.ts
+++ b/src/services/houseService.ts
@@ -2,6 +2,7 @@ import { collection, getDocs, addDoc } from "firebase/firestore";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { db, storage } from "../firebase/firebase";
 import { message } from "antd";
+import { convertToWebp } from "../utils/imageUtils";
 
 export const getLanguages = async () => {
   try {
@@ -42,8 +43,9 @@ export const addHouse = async (languageId: string, name: string, file?: File) =>
     let iconUrl = "";
     
     if (file) {
-      const storageRef = ref(storage, `house_icons/${file.name}`);
-      await uploadBytes(storageRef, file);
+      const optimizedFile = await convertToWebp(file);
+      const storageRef = ref(storage, `house_icons/${optimizedFile.name}`);
+      await uploadBytes(storageRef, optimizedFile);
       iconUrl = await getDownloadURL(storageRef);
     }
 

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -3,6 +3,7 @@ import { collection, addDoc, getDocs } from "firebase/firestore";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { db } from "../firebase/firebase";
 import { message } from "antd";
+import { convertToWebp } from "../utils/imageUtils";
 
 interface ImageData {
   houseName: string;
@@ -13,9 +14,10 @@ interface ImageData {
 
 export const uploadImage = async (file: File): Promise<string | null> => {
   try {
+    const optimizedFile = await convertToWebp(file);
     const storage = getStorage();
-    const storageRef = ref(storage, `images/${file.name}`);
-    await uploadBytes(storageRef, file);
+    const storageRef = ref(storage, `images/${optimizedFile.name}`);
+    await uploadBytes(storageRef, optimizedFile);
     return await getDownloadURL(storageRef);
   } catch (error) {
     message.error("Помилка завантаження зображення:");

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,16 +1,19 @@
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import { convertToWebp } from "../utils/imageUtils";
 
 export const uploadTexture = async (file: File): Promise<string> => {
+  const optimizedFile = await convertToWebp(file);
   const storage = getStorage();
-  const storageRef = ref(storage, `textures/${file.name}`);
-  await uploadBytes(storageRef, file);
+  const storageRef = ref(storage, `textures/${optimizedFile.name}`);
+  await uploadBytes(storageRef, optimizedFile);
   return await getDownloadURL(storageRef);
 };
 
 export const uploadLogo = async (file: File): Promise<string> => {
+  const optimizedFile = await convertToWebp(file);
   const storage = getStorage();
-  const storageRef = ref(storage, `logos/${file.name}`);
-  await uploadBytes(storageRef, file);
+  const storageRef = ref(storage, `logos/${optimizedFile.name}`);
+  await uploadBytes(storageRef, optimizedFile);
   return await getDownloadURL(storageRef);
 };
 

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,37 @@
+export const convertToWebp = (file: File, quality = 0.8): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    if (!file.type.startsWith('image/')) {
+      resolve(file);
+      return;
+    }
+
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Failed to get canvas context'));
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            const webpFile = new File([blob], file.name.replace(/\.[^/.]+$/, '') + '.webp', {
+              type: 'image/webp',
+            });
+            resolve(webpFile);
+          } else {
+            reject(new Error('Conversion to WebP failed'));
+          }
+        },
+        'image/webp',
+        quality
+      );
+    };
+    img.onerror = () => reject(new Error('Image loading failed'));
+    img.src = URL.createObjectURL(file);
+  });
+};


### PR DESCRIPTION
## Summary
- replace body-parser with built-in express.json
- make mail server port configurable via env
- add basic validation for incoming mail requests
- ignore build artifacts and environment files
- convert uploaded images to WebP before storing in Firebase

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce8d440c8330bed4f999e5621eb9